### PR TITLE
DSTEW-89: Add ModSecurity to uat

### DIFF
--- a/.helm/data-stewardship-civil-claims-api/templates/ingress.yaml
+++ b/.helm/data-stewardship-civil-claims-api/templates/ingress.yaml
@@ -19,6 +19,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/.helm/data-stewardship-civil-claims-api/values/uat.yaml
+++ b/.helm/data-stewardship-civil-claims-api/values/uat.yaml
@@ -16,9 +16,14 @@ service:
   port: 8080
 
 ingress:
+  className: modsec-non-prod
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-data-stewardship-civil-claims-api-dsp-chart-laa-data-stewardship-civil-claims-api-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-data-stewardship-payments-team,tag:namespace=laa-data-stewardship-civil-claims-api-uat"
   hosts: []
 
 resources:


### PR DESCRIPTION
## What

[Add ModSecurity to UAT](https://dsdmoj.atlassian.net/browse/DSTEW-89)

Enable CP's WAF using the dedicated ingress-controller, and using the default modsec rules.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
