### PR TITLE
Discuss: Set application root to SwaggerUI

### DIFF
--- a/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/RootRedirectController.java
+++ b/claims-data/service/src/main/java/uk/gov/justice/laa/dstew/payments/claimsdata/controller/RootRedirectController.java
@@ -1,0 +1,18 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Root redirection to Swagger documentation.
+ */
+@Controller
+public class RootRedirectController {
+
+  @GetMapping("/")
+  public void redirectToSwagger(HttpServletResponse response) throws IOException {
+    response.sendRedirect("/swagger-ui/index.html");
+  }
+}

--- a/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/RootRedirectControllerTest.java
+++ b/claims-data/service/src/test/java/uk/gov/justice/laa/dstew/payments/claimsdata/RootRedirectControllerTest.java
@@ -1,0 +1,25 @@
+package uk.gov.justice.laa.dstew.payments.claimsdata;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.dstew.payments.claimsdata.controller.RootRedirectController;
+
+@WebMvcTest(RootRedirectController.class)
+class RootRedirectControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void rootRedirectsToSwaggerUi() throws Exception {
+    mockMvc.perform(get("/"))
+        .andExpect(status().isFound()) // 302
+        .andExpect(header().string("Location", "/swagger-ui/index.html"));
+  }
+}


### PR DESCRIPTION
## What

Considering setting the application root `/` to SwaggerUI `/swagger-ui/index.html`

Why?

1. avoids the “blank root” problem where users hit / and get an empty or unclear response
2. no need to memorise the path
3. requesting the root URL, we immediately see the Swagger UI
4. 🤔 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
