### PR TITLE
Bump ccms-spring-boot to 0.0.39

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,7 @@ pluginManagement {
     }
 
     plugins {
-        id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.38'
+        id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.39'
     }
 }
 


### PR DESCRIPTION
## What

Bump ccms-spring-boot from 0.0.38 to 0.0.39

This resolve the [Uncontrolled Recursion](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-10734078) in org.apache.commons:commons-lang3@3.17.0

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
